### PR TITLE
fix: unmatched tracks not marked as Lost when dets_second is empty

### DIFF
--- a/src/trackers/bytetrack.cpp
+++ b/src/trackers/bytetrack.cpp
@@ -384,6 +384,13 @@ Eigen::MatrixXf ByteTrack::update(const Eigen::MatrixXf& dets,
         }
     }
     
+    // All unmatched by default, narrowed down inside the if block
+    std::vector<int> u_track2;
+    u_track2.reserve(r_tracked_stracks_ptrs.size());
+    for (size_t i = 0; i < r_tracked_stracks_ptrs.size(); ++i) {
+        u_track2.push_back(static_cast<int>(i));
+    }
+
     if (!detections_second.empty() && !r_tracked_stracks_ptrs.empty()) {
         Eigen::MatrixXf r_track_xyxy(r_tracked_stracks_ptrs.size(), 4);
         Eigen::MatrixXf det2_xyxy(detections_second.size(), 4);
@@ -397,7 +404,6 @@ Eigen::MatrixXf ByteTrack::update(const Eigen::MatrixXf& dets,
         Eigen::MatrixXf dists2 = utils::iou_distance(r_track_xyxy, det2_xyxy);
         auto assignment2 = utils::linear_assignment(dists2, 0.5f);
         
-        std::vector<int> u_track2, u_detection2;
         for (size_t i = 0; i < r_tracked_stracks_ptrs.size(); ++i) {
             bool matched = false;
             for (const auto& match : assignment2.matches) {
@@ -405,14 +411,16 @@ Eigen::MatrixXf ByteTrack::update(const Eigen::MatrixXf& dets,
             }
             if (!matched) u_track2.push_back(i);
         }
-        for (size_t i = 0; i < detections_second.size(); ++i) {
+        
+        u_track2.clear();
+        for (size_t i = 0; i < r_tracked_stracks_ptrs.size(); ++i) {
             bool matched = false;
             for (const auto& match : assignment2.matches) {
-                if (match[1] == static_cast<int>(i)) matched = true;
+                if (match[0] == static_cast<int>(i)) matched = true;
             }
-            if (!matched) u_detection2.push_back(i);
+            if (!matched) u_track2.push_back(static_cast<int>(i));
         }
-        
+
         for (const auto& match : assignment2.matches) {
             int itracked = match[0];
             int idet = match[1];
@@ -431,13 +439,14 @@ Eigen::MatrixXf ByteTrack::update(const Eigen::MatrixXf& dets,
                 refind_stracks.push_back(*track);
             }
         }
-        
-        for (int idx : u_track2) {
-            STrack* track = r_tracked_stracks_ptrs[idx];
-            if (track->state() != ByteTrackState::Lost) {
-                track->mark_lost();
-                lost_stracks_new.push_back(*track);
-            }
+    }
+
+    // Mark remaining unmatched tracks as lost regardless of second stage detections
+    for (int idx : u_track2) {
+        STrack* track = r_tracked_stracks_ptrs[idx];
+        if (track->state() != ByteTrackState::Lost) {
+            track->mark_lost();
+            lost_stracks_new.push_back(*track);
         }
     }
     


### PR DESCRIPTION
## Description
In `ByteTrack::update`, the entire second association stage was wrapped in a single `if (!detections_second.empty() && ...)` block. When there are no low-confidence detections around (which is pretty common), the whole block gets skipped — including the part responsible for marking unmatched tracks as `Lost`. Those tracks would just sit there with `Tracked` state and never go away, effectively becoming ghost tracks.

`u_track2` is now initialized with all indices of `r_tracked_stracks_ptrs` before the `if` block, and the `mark_lost` loop has been moved outside of it so it always runs. Also removed `u_detection2`, which was being computed but never used anywhere.

## Type of Change
- [x] Bug fix (non-breaking change fixing an issue)
- [ ] New feature (non-breaking change adding functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update
- [ ] Performance improvement

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have added tests that prove my fix/feature works
- [x] New and existing unit tests pass locally
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Testing
Tested manually by running the tracker on a video sequence where a person leaves the frame. Before the fix, the track would persist indefinitely in `active_tracks_` after the person disappeared. After the fix, the track is correctly marked as `Lost` and eventually removed.

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->